### PR TITLE
Pin version of crc32fast to 1.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["lib", "cdylib"]
 binread = { version = "2" }
 modular-bitfield = "0.10"
 thiserror = "1"
-crc32fast = "1.2"
+crc32fast = "=1.3.1"
 
 zstd = { version = "0.5", optional = true }
 ruzstd = { version = "=0.2.2", optional = true }


### PR DESCRIPTION
1.3.2 (and above, I imagine) don't compile with the `skyline` toolchain because they are missing something in STD