### PR TITLE
Add preliminary support for regional and localized stream files, and localized files.

### DIFF
--- a/src/arc_file.rs
+++ b/src/arc_file.rs
@@ -39,7 +39,7 @@ pub struct ArcFile {
 
 #[cfg(feature = "dir-listing")]
 fn parents_of_dir(dir: Hash40, labels: &mut HashLabels) -> Option<Vec<(Hash40, FileNode)>> {
-    let label = dir.label(&labels)?.to_owned();
+    let label = dir.label(labels)?.to_owned();
     let mut label = &label[..];
     let mut hashes = Vec::new();
     let mut last_hash = dir;
@@ -71,7 +71,7 @@ fn dir_listing_flat<'a>(
     let mut stream_dirs = Vec::new();
     for path_hash in fs.stream_hash_to_entries.iter().map(HashToIndex::hash40) {
         if let Some(label) = path_hash
-            .label(&labels)
+            .label(labels)
             .and_then(|label| label.rfind('/').map(|pos| label[..pos].to_owned()))
         {
             let mut label = &label[..];

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -151,14 +151,19 @@ pub struct QuickDir {
     pub index: u32,
 }
 
-#[bitfield]
 #[derive(BinRead, Debug, Clone, Copy)]
-#[br(map = Self::from_bytes)]
 pub struct StreamEntry {
-    pub hash: u32,
-    pub name_length: u8,
-    pub index: B24,
-    pub flags: u32,
+    pub path: HashToIndex,
+    pub flags: StreamEntryFlags,
+}
+
+#[bitfield]
+#[derive(BinRead, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[br(map = Self::from_bytes)]
+pub struct StreamEntryFlags {
+    pub is_regional: bool,
+    pub is_localized: bool,
+    pub unused: B30,
 }
 
 #[bitfield]

--- a/src/hash40.rs
+++ b/src/hash40.rs
@@ -50,27 +50,9 @@ impl From<HashToIndex> for Hash40 {
     }
 }
 
-impl From<&StreamEntry> for Hash40 {
-    fn from(hash_index: &StreamEntry) -> Self {
-        hash_index.hash40()
-    }
-}
-
-impl From<StreamEntry> for Hash40 {
-    fn from(hash_index: StreamEntry) -> Self {
-        hash_index.hash40()
-    }
-}
-
 impl HashToIndex {
     pub fn hash40(&self) -> Hash40 {
         Hash40((self.hash() as u64) + ((self.length() as u64) << 32))
-    }
-}
-
-impl StreamEntry {
-    pub fn hash40(&self) -> Hash40 {
-        Hash40((self.hash() as u64) + ((self.name_length() as u64) << 32))
     }
 }
 

--- a/src/hash40.rs
+++ b/src/hash40.rs
@@ -1,4 +1,4 @@
-use crate::{HashToIndex, QuickDir, StreamEntry};
+use crate::{HashToIndex, QuickDir};
 use binrw::BinRead;
 use crc32fast::Hasher;
 
@@ -234,4 +234,3 @@ mod tests {
         );
     }
 }
-

--- a/src/hash_labels.rs
+++ b/src/hash_labels.rs
@@ -22,7 +22,7 @@ impl HashLabels {
         HashLabels {
             labels: text
                 .lines()
-                .map(|line| (hash40(&line), line.to_owned()))
+                .map(|line| (hash40(line), line.to_owned()))
                 .collect(),
         }
     }

--- a/src/loaded_arc.rs
+++ b/src/loaded_arc.rs
@@ -87,4 +87,3 @@ pub struct LoadedSearchSection {
     pub path_list_indices: *const u32,
     pub path_list: *const PathListEntry, // ...
 }
-

--- a/src/lookups.rs
+++ b/src/lookups.rs
@@ -1,6 +1,6 @@
 use crate::*;
+use std::io::{self, Read, Seek, SeekFrom};
 use std::ops::Range;
-use std::io::{self, SeekFrom, Read, Seek};
 
 use region::Region;
 use thiserror::Error;
@@ -23,7 +23,6 @@ pub enum LookupError {
 mod arc_file;
 #[cfg(feature = "smash-runtime")]
 mod loaded_arc;
-
 
 /// The trait that allows different implementations of the arc to share the same code for making
 /// lookups into the filesystem use the same logic.
@@ -52,15 +51,19 @@ pub trait ArcLookup {
     fn get_file_section_offset(&self) -> u64;
     fn get_stream_section_offset(&self) -> u64;
     fn get_shared_section_offset(&self) -> u64;
-    
+
     // mutable access
     fn get_file_infos_mut(&mut self) -> &mut [FileInfo];
     fn get_dir_infos_mut(&mut self) -> &mut [DirInfo];
     fn get_file_datas_mut(&mut self) -> &mut [FileData];
     fn get_file_info_to_datas_mut(&mut self) -> &mut [FileInfoToFileData];
     fn get_folder_offsets_mut(&mut self) -> &mut [DirectoryOffset];
-    
-    fn get_file_contents<Hash: Into<Hash40>>(&self, hash: Hash, region: Region) -> Result<Vec<u8>, LookupError> {
+
+    fn get_file_contents<Hash: Into<Hash40>>(
+        &self,
+        hash: Hash,
+        region: Region,
+    ) -> Result<Vec<u8>, LookupError> {
         let hash = hash.into();
 
         self.get_nonstream_file_contents(hash, region)
@@ -70,11 +73,18 @@ pub trait ArcLookup {
             })
     }
 
-    fn get_dir_info_from_hash<Hash: Into<Hash40>>(&self, hash: Hash) -> Result<&DirInfo, LookupError> {
-        fn inner<Arc: ArcLookup + ?Sized>(arc: &Arc, hash: Hash40) -> Result<&DirInfo, LookupError> {
+    fn get_dir_info_from_hash<Hash: Into<Hash40>>(
+        &self,
+        hash: Hash,
+    ) -> Result<&DirInfo, LookupError> {
+        fn inner<Arc: ArcLookup + ?Sized>(
+            arc: &Arc,
+            hash: Hash40,
+        ) -> Result<&DirInfo, LookupError> {
             let dir_hash_to_info_index = arc.get_dir_hash_to_info_index();
 
-            let index = dir_hash_to_info_index.binary_search_by_key(&hash, |dir| dir.hash40())
+            let index = dir_hash_to_info_index
+                .binary_search_by_key(&hash, |dir| dir.hash40())
                 .map(|index| dir_hash_to_info_index[index].index() as usize)
                 .map_err(|_| LookupError::Missing)?;
 
@@ -84,11 +94,18 @@ pub trait ArcLookup {
         inner(self, hash.into())
     }
 
-    fn get_dir_info_from_hash_mut<Hash: Into<Hash40>>(&mut self, hash: Hash) -> Result<&mut DirInfo, LookupError> {
-        fn inner<Arc: ArcLookup + ?Sized>(arc: &mut Arc, hash: Hash40) -> Result<&mut DirInfo, LookupError> {
+    fn get_dir_info_from_hash_mut<Hash: Into<Hash40>>(
+        &mut self,
+        hash: Hash,
+    ) -> Result<&mut DirInfo, LookupError> {
+        fn inner<Arc: ArcLookup + ?Sized>(
+            arc: &mut Arc,
+            hash: Hash40,
+        ) -> Result<&mut DirInfo, LookupError> {
             let dir_hash_to_info_index = arc.get_dir_hash_to_info_index();
 
-            let index = dir_hash_to_info_index.binary_search_by_key(&hash, |dir| dir.hash40())
+            let index = dir_hash_to_info_index
+                .binary_search_by_key(&hash, |dir| dir.hash40())
                 .map(|index| dir_hash_to_info_index[index].index() as usize)
                 .map_err(|_| LookupError::Missing)?;
 
@@ -98,13 +115,21 @@ pub trait ArcLookup {
         inner(self, hash.into())
     }
 
-    fn get_nonstream_file_contents<Hash: Into<Hash40>>(&self, hash: Hash, region: Region) -> Result<Vec<u8>, LookupError> {
-        fn inner<Arc: ArcLookup + ?Sized>(arc: &Arc, hash: Hash40, region: Region) -> Result<Vec<u8>, LookupError> {
+    fn get_nonstream_file_contents<Hash: Into<Hash40>>(
+        &self,
+        hash: Hash,
+        region: Region,
+    ) -> Result<Vec<u8>, LookupError> {
+        fn inner<Arc: ArcLookup + ?Sized>(
+            arc: &Arc,
+            hash: Hash40,
+            region: Region,
+        ) -> Result<Vec<u8>, LookupError> {
             let file_info = arc.get_file_info_from_hash(hash)?;
             let folder_offset = arc.get_folder_offset(file_info, region);
             let file_data = arc.get_file_data(file_info, region);
 
-            arc.read_file_data(&file_data, folder_offset)
+            arc.read_file_data(file_data, folder_offset)
         }
 
         inner(self, hash.into(), region)
@@ -113,34 +138,45 @@ pub trait ArcLookup {
     fn get_stream_entry(&self, hash: Hash40) -> Result<&StreamEntry, LookupError> {
         let stream_entries = self.get_stream_entries();
 
-        Ok(stream_entries.iter()
+        stream_entries
+            .iter()
             .find(|entry| entry.path.hash40() == hash)
-            .ok_or(LookupError::Missing)?)
+            .ok_or(LookupError::Missing)
     }
 
     fn get_stream_data(&self, hash: Hash40, region: Region) -> Result<&StreamData, LookupError> {
         let stream_entries = self.get_stream_entries();
 
-        let stream_entry = stream_entries.iter()
+        let stream_entry = stream_entries
+            .iter()
             .find(|entry| entry.path.hash40() == hash)
             .ok_or(LookupError::Missing)?;
-        
+
         let mut stream_file_indice_index = stream_entry.path.index() as usize;
 
         if stream_entry.flags.is_regional() {
             stream_file_indice_index += region as usize - 1;
         }
         if stream_entry.flags.is_localized() {
-            stream_file_indice_index += region.get_locale().ok_or(LookupError::InvalidRegion)? as usize - 1;
+            stream_file_indice_index +=
+                region.get_locale().ok_or(LookupError::InvalidRegion)? as usize - 1;
         }
 
         let stream_data_index = self.get_stream_file_indices()[stream_file_indice_index] as usize;
-        
+
         Ok(&self.get_stream_datas()[stream_data_index])
     }
 
-    fn get_stream_file_contents<Hash: Into<Hash40>>(&self, hash: Hash, region: Region) -> Result<Vec<u8>, LookupError> {
-        fn inner<Arc: ArcLookup + ?Sized>(arc: &Arc, hash: Hash40, region: Region) -> Result<Vec<u8>, LookupError> {
+    fn get_stream_file_contents<Hash: Into<Hash40>>(
+        &self,
+        hash: Hash,
+        region: Region,
+    ) -> Result<Vec<u8>, LookupError> {
+        fn inner<Arc: ArcLookup + ?Sized>(
+            arc: &Arc,
+            hash: Hash40,
+            region: Region,
+        ) -> Result<Vec<u8>, LookupError> {
             let file_data = arc.get_stream_data(hash, region)?;
             arc.read_stream_file_data(file_data)
         }
@@ -153,44 +189,44 @@ pub trait ArcLookup {
 
         let mut reader = self.get_file_reader();
         reader.seek(SeekFrom::Start(offset))?;
-        
+
         let mut data = Vec::with_capacity(file_data.size as usize);
         let mut reader = Read::take(&mut reader, file_data.size as u64);
-        
+
         if reader.read_to_end(&mut data)? as u64 == file_data.size {
             Ok(data)
         } else {
-            Err(LookupError::FileRead(io::Error::new(io::ErrorKind::UnexpectedEof, "Failed to read data")))
+            Err(LookupError::FileRead(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Failed to read data",
+            )))
         }
     }
-    
+
     fn get_shared_files(&self, hash: Hash40, region: Region) -> Result<Vec<Hash40>, LookupError> {
         let metadata = self.get_file_metadata(hash, region)?;
 
         if metadata.is_shared {
             let hash_to_paths = self.get_file_hash_to_path_index();
 
-            let file_data_index = self.get_file_in_folder(
-                self.get_file_info_from_hash(hash)?,
-                region
-            ).file_data_index;
+            let file_data_index = self
+                .get_file_in_folder(self.get_file_info_from_hash(hash)?, region)
+                .file_data_index;
 
-            Ok(
-                hash_to_paths
-                    .iter()
-                    .filter_map(|hash_to_path| {
-                        let hash = hash_to_path.hash40();
-                        let file_info = self.get_file_info_from_hash(hash).ok()?;
-                        let file_in_folder = self.get_file_in_folder(file_info, region);
-                        let is_same_fd_index = file_in_folder.file_data_index == file_data_index;
-                        if is_same_fd_index {
-                            Some(hash)
-                        } else {
-                            None
-                        }
-                    })
-                    .collect()
-            )
+            Ok(hash_to_paths
+                .iter()
+                .filter_map(|hash_to_path| {
+                    let hash = hash_to_path.hash40();
+                    let file_info = self.get_file_info_from_hash(hash).ok()?;
+                    let file_in_folder = self.get_file_in_folder(file_info, region);
+                    let is_same_fd_index = file_in_folder.file_data_index == file_data_index;
+                    if is_same_fd_index {
+                        Some(hash)
+                    } else {
+                        None
+                    }
+                })
+                .collect())
         } else {
             Ok(Vec::from([]))
         }
@@ -200,14 +236,15 @@ pub trait ArcLookup {
         let file_info_buckets = self.get_file_info_buckets();
         let bucket_index = (hash.as_u64() % (file_info_buckets.len() as u64)) as usize;
         let bucket = &file_info_buckets[bucket_index];
-        
+
         &self.get_file_hash_to_path_index()[bucket.range()]
     }
 
     fn get_file_path_index_from_hash(&self, hash: Hash40) -> Result<FilePathIdx, LookupError> {
         let bucket = self.get_bucket_for_hash(hash);
-        
-        let index_in_bucket = bucket.binary_search_by_key(&hash, |group| group.hash40())
+
+        let index_in_bucket = bucket
+            .binary_search_by_key(&hash, |group| group.hash40())
             .map_err(|_| LookupError::Missing)?;
 
         Ok(FilePathIdx(bucket[index_in_bucket].index()))
@@ -216,7 +253,7 @@ pub trait ArcLookup {
     fn get_file_info_from_hash(&self, hash: Hash40) -> Result<&FileInfo, LookupError> {
         let path_index = self.get_file_path_index_from_hash(hash)?;
         let file_info = self.get_file_info_from_path_index(path_index);
-        
+
         Ok(file_info)
     }
 
@@ -225,7 +262,7 @@ pub trait ArcLookup {
             "bgm" | "smashappeal" | "movie" => crate::hash40::hash40(dir),
             dir if dir.starts_with("stream:/sound") => crate::hash40::hash40(&dir[14..]),
             "stream:/movie" => crate::hash40::hash40("movie"),
-            _ => return Err(LookupError::Missing)
+            _ => return Err(LookupError::Missing),
         };
 
         self.get_quick_dirs()
@@ -251,7 +288,8 @@ pub trait ArcLookup {
 
     fn get_file_in_folder(&self, file_info: &FileInfo, region: Region) -> FileInfoToFileData {
         if file_info.flags.is_regional() {
-            self.get_file_info_to_datas()[usize::from(file_info.info_to_data_index) + (region as usize)]
+            self.get_file_info_to_datas()
+                [usize::from(file_info.info_to_data_index) + (region as usize)]
         } else if file_info.flags.is_localized() {
             let locale_index = region.get_locale().unwrap_or(region::Locale::Japan) as usize;
             self.get_file_info_to_datas()[usize::from(file_info.info_to_data_index) + locale_index]
@@ -260,15 +298,24 @@ pub trait ArcLookup {
         }
     }
 
-    fn get_file_in_folder_mut(&mut self, file_info: &FileInfo, region: Region) -> &mut FileInfoToFileData {
+    fn get_file_in_folder_mut(
+        &mut self,
+        file_info: &FileInfo,
+        region: Region,
+    ) -> &mut FileInfoToFileData {
         if file_info.flags.is_regional() {
-            &mut self.get_file_info_to_datas_mut()[usize::from(file_info.info_to_data_index) + (region as usize)]
+            &mut self.get_file_info_to_datas_mut()
+                [usize::from(file_info.info_to_data_index) + (region as usize)]
         } else {
             &mut self.get_file_info_to_datas_mut()[file_info.info_to_data_index]
         }
     }
 
-    fn get_file_data_from_hash(&self, hash: Hash40, region: Region) -> Result<&FileData, LookupError> {
+    fn get_file_data_from_hash(
+        &self,
+        hash: Hash40,
+        region: Region,
+    ) -> Result<&FileData, LookupError> {
         Ok(self.get_file_data(self.get_file_info_from_hash(hash)?, region))
     }
 
@@ -292,13 +339,18 @@ pub trait ArcLookup {
 
     fn get_directory_dependency(&self, dir_info: &DirInfo) -> Option<RedirectionType> {
         if dir_info.flags.redirected() {
-            let directory_index = self.get_folder_offsets()[dir_info.path.index() as usize].directory_index;
+            let directory_index =
+                self.get_folder_offsets()[dir_info.path.index() as usize].directory_index;
 
             if directory_index != 0xFFFFFF {
                 if dir_info.flags.is_symlink() {
-                    Some(RedirectionType::Symlink(self.get_dir_infos()[directory_index as usize]))
+                    Some(RedirectionType::Symlink(
+                        self.get_dir_infos()[directory_index as usize],
+                    ))
                 } else {
-                    Some(RedirectionType::Shared(self.get_folder_offsets()[directory_index as usize]))
+                    Some(RedirectionType::Shared(
+                        self.get_folder_offsets()[directory_index as usize],
+                    ))
                 }
             } else {
                 None
@@ -308,13 +360,19 @@ pub trait ArcLookup {
         }
     }
 
-    fn read_file_data(&self, file_data: &FileData, folder_offset: u64) -> Result<Vec<u8>, LookupError> {
-        let offset = folder_offset + self.get_file_section_offset() + ((file_data.offset_in_folder as u64) <<  2);
+    fn read_file_data(
+        &self,
+        file_data: &FileData,
+        folder_offset: u64,
+    ) -> Result<Vec<u8>, LookupError> {
+        let offset = folder_offset
+            + self.get_file_section_offset()
+            + ((file_data.offset_in_folder as u64) << 2);
 
         if file_data.flags.compressed() && !file_data.flags.use_zstd() {
-            return Err(LookupError::UnsupportedCompression)
+            return Err(LookupError::UnsupportedCompression);
         }
-        
+
         let mut data = Vec::with_capacity(file_data.decomp_size as usize);
 
         let mut reader = self.get_file_reader();
@@ -335,8 +393,10 @@ pub trait ArcLookup {
         let path_index = self.get_file_path_index_from_hash(hash)?;
         let file_info = self.get_file_info_from_path_index(path_index);
         let folder_offset = self.get_folder_offset(file_info, region);
-        let file_data = self.get_file_data(&file_info, region);
-        let offset = folder_offset + self.get_file_section_offset() + ((file_data.offset_in_folder as u64) <<  2);
+        let file_data = self.get_file_data(file_info, region);
+        let offset = folder_offset
+            + self.get_file_section_offset()
+            + ((file_data.offset_in_folder as u64) << 2);
 
         Ok(offset)
     }
@@ -356,17 +416,27 @@ pub trait ArcLookup {
         max
     }
 
-    fn get_file_metadata<Hash: Into<Hash40>>(&self, hash: Hash, region: Region) -> Result<FileMetadata, LookupError> {
-        fn inner<Arc: ArcLookup + ?Sized>(arc: &Arc, hash: Hash40, region: Region) -> Result<FileMetadata, LookupError> {
+    fn get_file_metadata<Hash: Into<Hash40>>(
+        &self,
+        hash: Hash,
+        region: Region,
+    ) -> Result<FileMetadata, LookupError> {
+        fn inner<Arc: ArcLookup + ?Sized>(
+            arc: &Arc,
+            hash: Hash40,
+            region: Region,
+        ) -> Result<FileMetadata, LookupError> {
             match arc.get_file_path_index_from_hash(hash) {
                 Ok(path_index) => {
                     let file_path = &arc.get_file_paths()[path_index];
                     let file_info = arc.get_file_info_from_path_index(path_index);
                     let folder_offset = arc.get_folder_offset(file_info, region);
-                    let file_data = arc.get_file_data(&file_info, region);
+                    let file_data = arc.get_file_data(file_info, region);
 
-                    let offset = folder_offset + arc.get_file_section_offset() + ((file_data.offset_in_folder as u64) <<  2);
-                    
+                    let offset = folder_offset
+                        + arc.get_file_section_offset()
+                        + ((file_data.offset_in_folder as u64) << 2);
+
                     Ok(FileMetadata {
                         path_hash: file_path.path.hash40(),
                         ext_hash: file_path.ext.hash40(),
@@ -385,9 +455,8 @@ pub trait ArcLookup {
                     })
                 }
                 Err(LookupError::Missing) => {
-                    
                     let stream_entry = arc.get_stream_entry(hash)?;
-                    
+
                     let stream_data = arc.get_stream_data(hash, region)?;
 
                     Ok(FileMetadata {
@@ -407,7 +476,7 @@ pub trait ArcLookup {
                         uses_zstd: false,
                     })
                 }
-                Err(err) => Err(err)
+                Err(err) => Err(err),
             }
         }
 
@@ -422,15 +491,21 @@ pub trait SearchLookup {
     fn get_path_list_indices(&self) -> &[u32];
     fn get_path_list(&self) -> &[PathListEntry];
 
-    fn get_folder_path_index_from_hash(&self, hash: impl Into<Hash40>) -> Result<&HashToIndex, LookupError> {
+    fn get_folder_path_index_from_hash(
+        &self,
+        hash: impl Into<Hash40>,
+    ) -> Result<&HashToIndex, LookupError> {
         let folder_path_to_index = self.get_folder_path_to_index();
         match folder_path_to_index.binary_search_by_key(&hash.into(), |h| h.hash40()) {
             Ok(idx) => Ok(&folder_path_to_index[idx]),
-            Err(_) => Err(LookupError::Missing)
+            Err(_) => Err(LookupError::Missing),
         }
     }
 
-    fn get_folder_path_entry_from_hash(&self, hash: impl Into<Hash40>) -> Result<&FolderPathListEntry, LookupError> {
+    fn get_folder_path_entry_from_hash(
+        &self,
+        hash: impl Into<Hash40>,
+    ) -> Result<&FolderPathListEntry, LookupError> {
         let index = self.get_folder_path_index_from_hash(hash)?;
         if index.index() != 0xFF_FFFF {
             Ok(&self.get_folder_path_list()[index.index() as usize])
@@ -439,11 +514,14 @@ pub trait SearchLookup {
         }
     }
 
-    fn get_path_index_from_hash(&self, hash: impl Into<Hash40>) -> Result<&HashToIndex, LookupError> {
+    fn get_path_index_from_hash(
+        &self,
+        hash: impl Into<Hash40>,
+    ) -> Result<&HashToIndex, LookupError> {
         let path_to_index = self.get_path_to_index();
         match path_to_index.binary_search_by_key(&hash.into(), |h| h.hash40()) {
             Ok(idx) => Ok(&path_to_index[idx]),
-            Err(_) => Err(LookupError::Missing)
+            Err(_) => Err(LookupError::Missing),
         }
     }
 
@@ -456,7 +534,10 @@ pub trait SearchLookup {
         }
     }
 
-    fn get_path_list_entry_from_hash(&self, hash: impl Into<Hash40>) -> Result<&PathListEntry, LookupError> {
+    fn get_path_list_entry_from_hash(
+        &self,
+        hash: impl Into<Hash40>,
+    ) -> Result<&PathListEntry, LookupError> {
         let index = self.get_path_list_index_from_hash(hash)?;
         if index != 0xFF_FFFF {
             Ok(&self.get_path_list()[index as usize])
@@ -465,7 +546,10 @@ pub trait SearchLookup {
         }
     }
 
-    fn get_first_child_in_folder(&self, hash: impl Into<Hash40>) -> Result<&PathListEntry, LookupError> {
+    fn get_first_child_in_folder(
+        &self,
+        hash: impl Into<Hash40>,
+    ) -> Result<&PathListEntry, LookupError> {
         let folder_path = self.get_folder_path_entry_from_hash(hash)?;
         let index_idx = folder_path.get_first_child_index();
 
@@ -481,7 +565,10 @@ pub trait SearchLookup {
         }
     }
 
-    fn get_next_child_in_folder(&self, current_child: &PathListEntry) -> Result<&PathListEntry, LookupError> {
+    fn get_next_child_in_folder(
+        &self,
+        current_child: &PathListEntry,
+    ) -> Result<&PathListEntry, LookupError> {
         let index_idx = current_child.path.index() as usize;
         if index_idx == 0xFF_FFFF {
             return Err(LookupError::Missing);
@@ -567,7 +654,9 @@ mod tests {
     #[test]
     fn test_get_file_data() {
         let arc = ArcFile::open("/home/jam/re/ult/900/data.arc").unwrap();
-        let data = arc.get_file_contents("sound/config/bgm_property.bin", Region::UsEnglish).unwrap();
+        let data = arc
+            .get_file_contents("sound/config/bgm_property.bin", Region::UsEnglish)
+            .unwrap();
 
         //std::fs::write("bgm_property.bin", data).unwrap();
 
@@ -577,11 +666,20 @@ mod tests {
     #[test]
     fn test_get_stream_file() {
         let arc = ArcFile::open("/home/jam/re/ult/900/data.arc").unwrap();
-        
-        let labels = crate::hash_labels::HashLabels::from_file("/home/jam/Downloads/hashes.txt").unwrap();
-        dbg!(arc.file_system.stream_entries[0].path.hash40().label(&labels));
 
-        let data = arc.get_file_contents("stream:/sound/bgm/bgm_a10_malrpg2_zarazarasabaku.nus3audio", Region::UsEnglish).unwrap();
+        let labels =
+            crate::hash_labels::HashLabels::from_file("/home/jam/Downloads/hashes.txt").unwrap();
+        dbg!(arc.file_system.stream_entries[0]
+            .path
+            .hash40()
+            .label(&labels));
+
+        let data = arc
+            .get_file_contents(
+                "stream:/sound/bgm/bgm_a10_malrpg2_zarazarasabaku.nus3audio",
+                Region::UsEnglish,
+            )
+            .unwrap();
 
         //std::fs::write("bgm_a10_malrpg2_zarazarasabaku.nus3audio", data).unwrap();
     }
@@ -590,14 +688,15 @@ mod tests {
     fn test_get_shared() {
         let hash: Hash40 = "fighter/mario/model/body/c00/leyes_eye_mario_l_col.nutexb".into();
 
-
-        let labels = crate::hash_labels::HashLabels::from_file("/home/jam/Downloads/hashes.txt").unwrap();
+        let labels =
+            crate::hash_labels::HashLabels::from_file("/home/jam/Downloads/hashes.txt").unwrap();
         dbg!(hash.label(&labels));
 
         let arc = ArcFile::open("/home/jam/re/ult/900/data.arc").unwrap();
         let shared_files = arc.get_shared_files(hash, Region::UsEnglish).unwrap();
 
-        let shared_files: Vec<Option<&str>> = shared_files.into_iter()
+        let shared_files: Vec<Option<&str>> = shared_files
+            .into_iter()
             .map(|hash| hash.label(&labels))
             .collect();
 
@@ -612,14 +711,29 @@ mod tests {
         let start = dir_info.child_dir_start_index as usize;
         let end = (dir_info.child_dir_start_index as usize) + (dir_info.child_dir_count as usize);
 
-        let children = &arc.file_system.folder_child_hashes[start..end].iter()
+        let children = &arc.file_system.folder_child_hashes[start..end]
+            .iter()
             .map(|child| &arc.file_system.dir_infos[child.index() as usize])
             .collect::<Vec<_>>();
         let labels = crate::hash_labels::HashLabels::from_file("H:/Downloads/hashes.txt").unwrap();
 
         for child in children {
-            eprint!("{} ", child.name.label(&labels).map(String::from).unwrap_or_else(|| format!("0x{:X}", child.name.as_u64())));
-            eprintln!("{}", child.parent.label(&labels).map(String::from).unwrap_or_else(|| format!("0x{:X}", child.parent.as_u64())));
+            eprint!(
+                "{} ",
+                child
+                    .name
+                    .label(&labels)
+                    .map(String::from)
+                    .unwrap_or_else(|| format!("0x{:X}", child.name.as_u64()))
+            );
+            eprintln!(
+                "{}",
+                child
+                    .parent
+                    .label(&labels)
+                    .map(String::from)
+                    .unwrap_or_else(|| format!("0x{:X}", child.parent.as_u64()))
+            );
         }
 
         dbg!(dir_info);
@@ -631,7 +745,8 @@ mod tests {
 
         let mut extensions = std::collections::HashSet::new();
 
-        let labels = crate::hash_labels::HashLabels::from_file("/home/jam/Downloads/hashes.txt").unwrap();
+        let labels =
+            crate::hash_labels::HashLabels::from_file("/home/jam/Downloads/hashes.txt").unwrap();
         for file in arc.get_stream_listing("stream:/sound/bgm").unwrap() {
             if let Some(label) = file.path.hash40().label(&labels) {
                 extensions.insert(label.rsplit(".").next().unwrap());
@@ -646,31 +761,38 @@ mod tests {
     fn dir_info_print_filepaths(arc: &ArcFile, dir_info: &DirInfo, labels: &HashLabels) {
         dbg!(&dir_info);
 
-        
+        let file_infos = &arc.get_file_infos()[dir_info.file_info_range()]
+            .iter()
+            .collect::<Vec<_>>();
 
-            let file_infos = &arc.get_file_infos()[dir_info.file_info_range()].iter().collect::<Vec<_>>();
+        for infos in file_infos {
+            println!(
+                "{}",
+                arc.get_file_paths()[infos.file_path_index]
+                    .path
+                    .hash40()
+                    .label(&labels)
+                    .unwrap_or("Unk")
+            );
+        }
 
-            for infos in file_infos {
-                println!("{}", arc.get_file_paths()[infos.file_path_index].path.hash40().label(&labels).unwrap_or("Unk"));
-            }
+        if let Some(dep) = arc.get_directory_dependency(dir_info) {
+            println!("Redirection");
 
-            if let Some(dep) = arc.get_directory_dependency(dir_info) {
-                println!("Redirection");
-
-                match dep {
-                    RedirectionType::Symlink(dir_info) => {
-                        println!("DirInfo");
-                        dir_info_print_filepaths(arc, &dir_info, labels);
-                    },
-                    RedirectionType::Shared(dir_offs) => {
-                        println!("DirOffset");
-                        dir_offset_print_filepaths(arc, &dir_offs, labels);
-                    },
+            match dep {
+                RedirectionType::Symlink(dir_info) => {
+                    println!("DirInfo");
+                    dir_info_print_filepaths(arc, &dir_info, labels);
                 }
-            };
+                RedirectionType::Shared(dir_offs) => {
+                    println!("DirOffset");
+                    dir_offset_print_filepaths(arc, &dir_offs, labels);
+                }
+            }
+        };
 
-            // println!("Printing children");
-            // dir_info_print_children(arc, dir_info, labels);
+        // println!("Printing children");
+        // dir_info_print_children(arc, dir_info, labels);
     }
 
     fn dir_offset_print_filepaths(arc: &ArcFile, dir_info: &DirectoryOffset, labels: &HashLabels) {
@@ -681,7 +803,14 @@ mod tests {
         let file_infos = &arc.get_file_infos()[start..end].iter().collect::<Vec<_>>();
 
         for infos in file_infos {
-            println!("{}", arc.get_file_paths()[infos.file_path_index].path.hash40().label(&labels).unwrap());
+            println!(
+                "{}",
+                arc.get_file_paths()[infos.file_path_index]
+                    .path
+                    .hash40()
+                    .label(&labels)
+                    .unwrap()
+            );
         }
     }
 
@@ -689,7 +818,8 @@ mod tests {
         let start = dir_info.child_dir_start_index as usize;
         let end = (dir_info.child_dir_start_index as usize) + (dir_info.child_dir_count as usize);
 
-        let children = &arc.file_system.folder_child_hashes[start..end].iter()
+        let children = &arc.file_system.folder_child_hashes[start..end]
+            .iter()
             .map(|child| &arc.file_system.dir_infos[child.index() as usize])
             .collect::<Vec<_>>();
 
@@ -703,10 +833,12 @@ mod tests {
         let arc = ArcFile::open("H:/Documents/Smash/update/romfs/data_1010.arc").unwrap();
         let labels = crate::hash_labels::HashLabels::from_file("H:/Downloads/hashes.txt").unwrap();
 
-        let dir_info = dbg!(arc.get_dir_info_from_hash(Hash40::from("fighter/jack/c00")).unwrap());
+        let dir_info = dbg!(arc
+            .get_dir_info_from_hash(Hash40::from("fighter/jack/c00"))
+            .unwrap());
 
         println!("Files:");
-        dir_info_print_filepaths(&arc, &dir_info, &labels); 
+        dir_info_print_filepaths(&arc, &dir_info, &labels);
     }
 }
 
@@ -766,7 +898,7 @@ mod tests {
 //     fn setup_children(&mut self) {
 //         if let WalkdirDirectoryType::Directory(directory) = self.current {
 //             if self.child_index < directory.child_dir_count {
-                
+
 //             }
 //         }
 //     }
@@ -806,7 +938,7 @@ mod tests {
 //                 index: index - 1
 //             })
 //         } else {
-            
+
 //         }
 //     }
 // }

--- a/src/lookups/arc_file.rs
+++ b/src/lookups/arc_file.rs
@@ -1,5 +1,5 @@
-use std::io;
 use crate::*;
+use std::io;
 
 impl ArcLookup for ArcFile {
     fn get_file_info_buckets(&self) -> &[FileInfoBucket] {
@@ -100,7 +100,6 @@ impl ArcLookup for ArcFile {
 }
 
 use std::sync::MutexGuard;
-
 
 // Wrapper type for implementing Read + Seek for MutexGuard
 #[repr(transparent)]

--- a/src/lookups/loaded_arc.rs
+++ b/src/lookups/loaded_arc.rs
@@ -1,13 +1,9 @@
-use std::{
-    fs::File,
-    slice,
-    io::BufReader,
-};
+use std::{fs::File, io::BufReader, slice};
 
-use crate::loaded_arc::{LoadedArc, LoadedSearchSection};
-use crate::{ArcLookup, SearchLookup};
-use crate::SeekRead;
 use crate::filesystem::*;
+use crate::loaded_arc::{LoadedArc, LoadedSearchSection};
+use crate::SeekRead;
+use crate::{ArcLookup, SearchLookup};
 
 impl ArcLookup for LoadedArc {
     fn get_file_info_buckets(&self) -> &[FileInfoBucket] {
@@ -68,7 +64,7 @@ impl ArcLookup for LoadedArc {
     fn get_file_infos(&self) -> &[FileInfo] {
         unsafe {
             let fs = *self.fs_header;
-            let table_size = fs.file_info_count + fs.file_data_count_2 + fs.extra_count ;
+            let table_size = fs.file_info_count + fs.file_data_count_2 + fs.extra_count;
             slice::from_raw_parts(self.file_infos, table_size as _)
         }
     }
@@ -76,7 +72,7 @@ impl ArcLookup for LoadedArc {
     fn get_file_infos_mut(&mut self) -> &mut [FileInfo] {
         unsafe {
             let fs = *self.fs_header;
-            let table_size = fs.file_info_count + fs.file_data_count_2 + fs.extra_count ;
+            let table_size = fs.file_info_count + fs.file_data_count_2 + fs.extra_count;
             slice::from_raw_parts_mut(self.file_infos, table_size as _)
         }
     }
@@ -84,7 +80,7 @@ impl ArcLookup for LoadedArc {
     fn get_file_info_to_datas(&self) -> &[FileInfoToFileData] {
         unsafe {
             let fs = *self.fs_header;
-            let table_size = fs.file_info_sub_index_count  + fs.file_data_count_2 + fs.extra_count_2;
+            let table_size = fs.file_info_sub_index_count + fs.file_data_count_2 + fs.extra_count_2;
             slice::from_raw_parts(self.file_info_to_datas, table_size as _)
         }
     }
@@ -92,7 +88,7 @@ impl ArcLookup for LoadedArc {
     fn get_file_info_to_datas_mut(&mut self) -> &mut [FileInfoToFileData] {
         unsafe {
             let fs = *self.fs_header;
-            let table_size = fs.file_info_sub_index_count  + fs.file_data_count_2 + fs.extra_count_2;
+            let table_size = fs.file_info_sub_index_count + fs.file_data_count_2 + fs.extra_count_2;
             slice::from_raw_parts_mut(self.file_info_to_datas, table_size as _)
         }
     }
@@ -104,7 +100,7 @@ impl ArcLookup for LoadedArc {
             slice::from_raw_parts(self.file_datas, table_size as _)
         }
     }
-    
+
     fn get_file_datas_mut(&mut self) -> &mut [FileData] {
         unsafe {
             let fs = *self.fs_header;
@@ -188,33 +184,23 @@ impl ArcLookup for LoadedArc {
 
 impl SearchLookup for LoadedArc {
     fn get_folder_path_to_index(&self) -> &[HashToIndex] {
-        unsafe {
-            (*self.loaded_file_system_search).get_folder_path_to_index()
-        }
+        unsafe { (*self.loaded_file_system_search).get_folder_path_to_index() }
     }
 
     fn get_folder_path_list(&self) -> &[FolderPathListEntry] {
-        unsafe {
-            (*self.loaded_file_system_search).get_folder_path_list()
-        }
+        unsafe { (*self.loaded_file_system_search).get_folder_path_list() }
     }
 
     fn get_path_to_index(&self) -> &[HashToIndex] {
-        unsafe {
-            (*self.loaded_file_system_search).get_path_to_index()
-        }
+        unsafe { (*self.loaded_file_system_search).get_path_to_index() }
     }
 
     fn get_path_list_indices(&self) -> &[u32] {
-        unsafe {
-            (*self.loaded_file_system_search).get_path_list_indices()
-        }
+        unsafe { (*self.loaded_file_system_search).get_path_list_indices() }
     }
 
     fn get_path_list(&self) -> &[PathListEntry] {
-        unsafe {
-            (*self.loaded_file_system_search).get_path_list()
-        }
+        unsafe { (*self.loaded_file_system_search).get_path_list() }
     }
 }
 

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,5 +1,5 @@
-use std::str::FromStr;
 use std::convert::Infallible;
+use std::str::FromStr;
 
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -18,7 +18,7 @@ impl From<usize> for Locale {
             2 => UnitedStates,
             3 => Europe,
 
-            _ => None
+            _ => None,
         }
     }
 }
@@ -50,7 +50,7 @@ impl FromStr for Locale {
             "us" => UnitedStates,
             "eu" => Europe,
 
-            _ => None
+            _ => None,
         })
     }
 }
@@ -93,7 +93,7 @@ impl Region {
             Region::ChinaChinese => Some(Locale::Japan),
             Region::TaiwanChinese => Some(Locale::Japan),
 
-            _ => None
+            _ => None,
         }
     }
 }
@@ -117,7 +117,7 @@ impl From<usize> for Region {
             13 => ChinaChinese,
             14 => TaiwanChinese,
 
-            _ => None
+            _ => None,
         }
     }
 }
@@ -160,7 +160,7 @@ impl FromStr for Region {
             "zh_cn" => ChinaChinese,
             "zh_tw" => TaiwanChinese,
 
-            _ => None
+            _ => None,
         })
     }
 }

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,5 +1,60 @@
 use std::str::FromStr;
 use std::convert::Infallible;
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Locale {
+    None = 0,
+    Japan = 1,
+    UnitedStates = 2,
+    Europe = 3,
+}
+
+impl From<usize> for Locale {
+    fn from(r: usize) -> Locale {
+        use Locale::*;
+        match r {
+            1 => Japan,
+            2 => UnitedStates,
+            3 => Europe,
+
+            _ => None
+        }
+    }
+}
+
+impl From<u32> for Locale {
+    fn from(x: u32) -> Self {
+        Locale::from(x as usize)
+    }
+}
+
+impl From<u16> for Locale {
+    fn from(x: u16) -> Self {
+        Locale::from(x as usize)
+    }
+}
+
+impl From<u8> for Locale {
+    fn from(x: u8) -> Self {
+        Locale::from(x as usize)
+    }
+}
+
+impl FromStr for Locale {
+    type Err = Infallible;
+    fn from_str(x: &str) -> Result<Self, Self::Err> {
+        use Locale::*;
+        Ok(match x {
+            "jp" => Japan,
+            "us" => UnitedStates,
+            "eu" => Europe,
+
+            _ => None
+        })
+    }
+}
+
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Region {
@@ -18,6 +73,29 @@ pub enum Region {
     Korean = 12,
     ChinaChinese = 13,
     TaiwanChinese = 14,
+}
+
+impl Region {
+    pub fn get_locale(&self) -> Option<Locale> {
+        match self {
+            Region::Japanese => Some(Locale::Japan),
+            Region::UsEnglish => Some(Locale::UnitedStates),
+            Region::UsFrench => Some(Locale::UnitedStates),
+            Region::UsSpanish => Some(Locale::UnitedStates),
+            Region::EuEnglish => Some(Locale::Europe),
+            Region::EuFrench => Some(Locale::Europe),
+            Region::EuSpanish => Some(Locale::Europe),
+            Region::EuGerman => Some(Locale::Europe),
+            Region::EuDutch => Some(Locale::Europe),
+            Region::EuItalian => Some(Locale::Europe),
+            Region::EuRussian => Some(Locale::Europe),
+            Region::Korean => Some(Locale::Japan),
+            Region::ChinaChinese => Some(Locale::Japan),
+            Region::TaiwanChinese => Some(Locale::Japan),
+
+            _ => None
+        }
+    }
 }
 
 impl From<usize> for Region {
@@ -84,5 +162,38 @@ impl FromStr for Region {
 
             _ => None
         })
+    }
+}
+
+impl std::fmt::Display for Region {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Region::None => write!(f, ""),
+            Region::Japanese => write!(f, "jp_ja"),
+            Region::UsEnglish => write!(f, "us_en"),
+            Region::UsFrench => write!(f, "us_fr"),
+            Region::UsSpanish => write!(f, "us_es"),
+            Region::EuEnglish => write!(f, "eu_en"),
+            Region::EuFrench => write!(f, "eu_fr"),
+            Region::EuSpanish => write!(f, "eu_es"),
+            Region::EuGerman => write!(f, "eu_de"),
+            Region::EuDutch => write!(f, "eu_nl"),
+            Region::EuItalian => write!(f, "eu_it"),
+            Region::EuRussian => write!(f, "eu_ru"),
+            Region::Korean => write!(f, "kr_ko"),
+            Region::ChinaChinese => write!(f, "zh_cn"),
+            Region::TaiwanChinese => write!(f, "zh_tw"),
+        }
+    }
+}
+
+impl std::fmt::Display for Locale {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Locale::None => write!(f, ""),
+            Locale::Japan => write!(f, "jp"),
+            Locale::UnitedStates => write!(f, "us"),
+            Locale::Europe => write!(f, "eu"),
+        }
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,8 +1,8 @@
-use crate::{ArcFile, HashLabels, Hash40};
+use crate::{ArcFile, Hash40, HashLabels};
 
-use rayon::prelude::*;
-use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use rayon::prelude::*;
 
 use std::collections::HashMap;
 
@@ -10,10 +10,13 @@ impl HashLabels {
     pub(crate) fn get_ordered_matches(&self, search: &str) -> Vec<Hash40> {
         let matcher = SkimMatcherV2::default();
 
-        let mut labels: Vec<(i64, Hash40)> = self.labels
+        let mut labels: Vec<(i64, Hash40)> = self
+            .labels
             .par_iter()
             .filter_map(|(hash, label)| {
-                matcher.fuzzy_match(&label, search).map(|score| (score, *hash))
+                matcher
+                    .fuzzy_match(label, search)
+                    .map(|score| (score, *hash))
             })
             .collect();
 
@@ -27,15 +30,17 @@ impl ArcFile {
     pub fn generate_search_cache(&self) -> SearchCache {
         let mut cache = HashMap::<Hash40, Vec<Hash40>>::new();
         for file_path in &self.file_system.file_paths {
-            cache.entry(file_path.file_name.hash40())
+            cache
+                .entry(file_path.file_name.hash40())
                 .or_default()
                 .push(file_path.path.hash40());
 
-            cache.entry(file_path.parent.hash40())
+            cache
+                .entry(file_path.parent.hash40())
                 .or_default()
                 .push(file_path.path.hash40());
         }
-            
+
         SearchCache(cache)
     }
 }
@@ -47,15 +52,15 @@ impl SearchCache {
     pub fn search(&self, term: &str, labels: &HashLabels, max: usize) -> Vec<Hash40> {
         let matches = labels.get_ordered_matches(term);
 
-        matches.into_iter()
-            .map(|search_match| {
+        matches
+            .into_iter()
+            .flat_map(|search_match| {
                 self.0
                     .get(&search_match)
                     .map(|x| &x[..])
                     .unwrap_or_else(|| &[][..])
                     .iter()
             })
-            .flatten()
             .take(max)
             .copied()
             .collect()
@@ -70,7 +75,6 @@ mod tests {
     fn search() {
         let labels = HashLabels::from_file("hash_labels.txt").unwrap();
         let arc = ArcFile::open("data.arc").unwrap();
-
 
         let gen_cache = std::time::Instant::now();
         let search_cache = arc.generate_search_cache();

--- a/src/table_indices.rs
+++ b/src/table_indices.rs
@@ -121,4 +121,3 @@ impl From<usize> for FileDataIdx {
         FileDataIdx(index as u32)
     }
 }
-

--- a/src/zstd_backend/libzstd.rs
+++ b/src/zstd_backend/libzstd.rs
@@ -1,2 +1,2 @@
-pub use zstd::stream::copy_decode;
 pub use zstd::decode_all;
+pub use zstd::stream::copy_decode;

--- a/src/zstd_backend/mod.rs
+++ b/src/zstd_backend/mod.rs
@@ -18,11 +18,12 @@ compile_error!("At least one ZSTD backend feature must be enabled");
 
 #[cfg(not(any(feature = "libzstd", feature = "rust-zstd")))]
 mod template {
-    use std::io::{Read, Write, Result};
+    use std::io::{Read, Result, Write};
 
     pub fn copy_decode<R, W>(mut _source: R, mut _destination: W) -> Result<()>
-        where R: Read,
-              W: Write,
+    where
+        R: Read,
+        W: Write,
     {
         todo!()
     }

--- a/src/zstd_backend/rust_zstd.rs
+++ b/src/zstd_backend/rust_zstd.rs
@@ -1,19 +1,20 @@
-use std::io::{self, Error, ErrorKind, Read, Write, Result};
 use ruzstd::streaming_decoder::StreamingDecoder;
+use std::io::{self, Error, ErrorKind, Read, Result, Write};
 
 pub fn copy_decode<R, W>(mut source: R, mut destination: W) -> Result<()>
-    where R: Read,
-          W: Write,
+where
+    R: Read,
+    W: Write,
 {
-    let mut decoder = StreamingDecoder::new(&mut source)
-        .map_err(|err| Error::new(ErrorKind::Other, err))?;
+    let mut decoder =
+        StreamingDecoder::new(&mut source).map_err(|err| Error::new(ErrorKind::Other, err))?;
 
     io::copy(&mut decoder, &mut destination).map(|_| ())
 }
 
 pub fn decode_all<R: Read>(mut source: R) -> Result<Vec<u8>> {
-    let mut decoder = StreamingDecoder::new(&mut source)
-        .map_err(|err| Error::new(ErrorKind::Other, err))?;
+    let mut decoder =
+        StreamingDecoder::new(&mut source).map_err(|err| Error::new(ErrorKind::Other, err))?;
 
     let mut out = Vec::new();
     decoder.read_to_end(&mut out)?;


### PR DESCRIPTION
This pull request implements the proper handling of files with the is_localized tag within FileInfoFlags (inside the ArcLookup::get_file_in_folder function) and stream files with either regional or localization entries (inside the ArcLookup::get_stream_data function), defines the StreamEntry's flags as its own bitfield struct, replaces the other members (hash, name_length, index) with a HashToIndex, and adds a new function to ArcLookup, named get_stream_entry.

It also introduces a new helper enumerated type: Locale. A member function was added to the Region struct allowing for a Region to be converted to a Locale. std::fmt::Display implementations were added to both Locale and Region.