### PR TITLE
Update dependencies + version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ license = "MIT"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-binrw = "0.8.4"
-modular-bitfield = "0.10"
+binrw = "0.11.2"
+modular-bitfield = "0.11.2"
 thiserror = "1"
 crc32fast = "1.3.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smash-arc"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["jam1garner <8260240+jam1garner@users.noreply.github.com>"]
 edition = "2018"
 description = "A Rust library for working with Smash Ultimate's data.arc files"


### PR DESCRIPTION
This PR updates both binrw and modular-bitfield to 0.11.2. To accommodate this the two ``#[br(map)]``'d compressed file system members in ``ArcFile`` are now split off via ``#[br(temp)]`` and ``#[br(calc)]``.